### PR TITLE
Extra magic for p, g, and gg using executing

### DIFF
--- a/boxx/tool/toolFunction.py
+++ b/boxx/tool/toolFunction.py
@@ -63,7 +63,7 @@ def setInterval(fun, inter, maxTimes=None):
             maxTimes[0] -= 1
             if maxTimes[0] <= 0:
                 return 
-        setTimeOut(interFun, inter)
+        setTimeout(interFun, inter)
     interFun()
 
 from multiprocessing import Pool as PoolMp
@@ -239,7 +239,7 @@ class multiThread():
                 r = fun(*l,**kv)
             finally:
                 self.left += 1
-        self.l.append(setTimeOut(f))
+        self.l.append(setTimeout(f))
         if len(self.l)>100:
             self.l = self.l[-90:]
     f = lambda fun,*l,**kv:fun(*l,**kv) #用于测试单线程的性能

--- a/boxx/tool/toolLog.py
+++ b/boxx/tool/toolLog.py
@@ -3,6 +3,8 @@
 from __future__ import unicode_literals
 from __future__ import print_function
 
+import executing
+
 from .toolStructObj import addCall, dicto, FunAddMagicMethod, getfathers, typeNameOf, typestr
 from .toolSystem import getRootFrame, getFatherFrames
 from ..ylsys import py2
@@ -1170,7 +1172,11 @@ def generaPAndLc():
             else:
                 pass
 #                pblue('%s: %s'%(clf.p%'As pp by p', x))
-                print(x)
+                try:
+                    ex = executing.Source.executing(sys._getframe(1))
+                    print(ex.source.asttokens().get_text(ex.node.right), '=', x)
+                except:
+                    print(x)
             return x
         __sub__ = printt
         __lshift__ = printt

--- a/boxx/tool/toolLog.py
+++ b/boxx/tool/toolLog.py
@@ -12,6 +12,7 @@ from ..ylcompat import printf, unicode
 from ..ylcompat import istype
 
 import os,sys,time
+import ast
 import math
 import re
 from collections import defaultdict
@@ -933,6 +934,17 @@ class GlobalG(GlobalGCore):
         log = global_g_paras[id(self)].log
         transport = TransportToRootFrame(name,log)
         transport(v)
+
+    def __pow__(self, v):
+        ex = executing.Source.executing(sys._getframe(1))
+        op = ex.node.right
+        if not isinstance(op, ast.Name):
+            raise TypeError('Only variables can be transported directly')
+        self.__setattr__(op.id, v)
+
+    __sub__ = __truediv__ = __div__ = __mul__ = __add__ = __eq__ = __pow__
+
+
 g = GlobalG()
 gg = GlobalG(log=True)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ snakeviz
 fn
 pyopengl
 seaborn
+executing
+asttokens


### PR DESCRIPTION
With these changes, `p` will show the source code of expressions being printed and `g` can transport variables without specifying the name, e.g. `g / y` instead of `g.y / y`. Here's an example script:

```python
from boxx import p, g, gg

x = [i * 2 for i in range(5)]
p / [p / x[0], p ** x[1], p - x[2], p << x[3], p >> x[4]]


def foo():
    y = 4
    z = 5
    gg / y
    g / z


foo()
print(y, z)
```

Output:

```python
x[0] = 0
x[1] = 2
x[2] = 4
x[3] = 6
x[4] = 8
[p / x[0], p ** x[1], p - x[2], p << x[3], p >> x[4]] = [0, 2, 4, 6, 8]
gg.y:"4"
4 5
```

This is thanks to my library [executing](https://github.com/alexmojaki/executing).

I would appreciate it if you could add some links to some of my other debugging libraries which I think your users would be interested in:

- [snoop](https://github.com/alexmojaki/snoop): a better version of PySnooper. It includes a function `pp.deep` which is similar to `logc` but shows all sub-expressions, not just variables.
- [heartrate](https://github.com/alexmojaki/heartrate): a real time visualisation of a program similar to pyheat.